### PR TITLE
tests now run from Pkg.test

### DIFF
--- a/test/CryptoTests.jl
+++ b/test/CryptoTests.jl
@@ -5,7 +5,7 @@ using Test
 function testecdsa(verbose=true)
     #https://www.ietf.org/rfc/rfc6979.txt
     if verbose println("Testing ECDSA") end
-    tests = readlines("./test/ecdsa.txt")
+    tests = readlines("ecdsa.txt")
     tests = [split(t, " = ")[2] for t in tests]
 
     i = 1

--- a/test/EllipticCurveTests.jl
+++ b/test/EllipticCurveTests.jl
@@ -4,7 +4,7 @@ using Test
 
 function testcurve(curve, verbose=true)
     if verbose println("Testing $curve:") end
-    tests = readlines("./test/$curve.txt")
+    tests = readlines("$curve.txt")
     G = curve(UInt).G
 
     for i in 1:4:length(tests)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+using BinaryECC
+
 include("BFieldTests.jl")
 include("EllipticCurveTests.jl")
 include("CryptoTests.jl")


### PR DESCRIPTION
Added a missing “using BinaryECC” and fixed two relative paths, such that
```
julia> using Pkg; Pkg.test("BinaryECC")
```
and
```
(@v1.6) pkg> test BinaryECC
```
now work.